### PR TITLE
Change exit behavior, allow bias updates, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ The main binary has three options available (with suboptions for train and predi
 As noted above, the first option is to train a new neural network from scratch. To get started, examine the following syntax:
 
 ```
-./target/main train <path to labels> <path to images> <learning rate> <use biases> <number of layers> <[neurons in each layer]> <images to train on> <model name>
+./target/main train <path to labels> <path to images> <learning rate> <use biases> <number of layers> <[neurons in each layer]> <images to train on> <epochs> <model name>
 ```
 
 A complete example is listed below:
 ```
-./target/main train data/train-labels-idx1-ubyte data/train-images-idx3-ubyte 0.1 true 3 784 100 10 1500 small_100.model
+./target/main train data/train-labels-idx1-ubyte data/train-images-idx3-ubyte 0.1 true 3 784 100 10 1500 2 small_100.model
 ```
 
 The example reveals that: we want to train a new model, using a **learning rate** of 0.1, we want to use biases, there are **3** total layers (including input). The first layer has 784 neurons, the second has 100, and the output has 10. We want to train on a subset of 1500 images and we want to export the model to file `small_100.model`.
@@ -74,7 +74,7 @@ The example reveals that: we want to train a new model, using a **learning rate*
 Running the example above produces the following output:
 
 ```
-$ ./target/main train data/train-labels-idx1-ubyte data/train-images-idx3-ubyte 0.1 true 3 784 100 10 1500 small_100.model
+$ ./target/main train data/train-labels-idx1-ubyte data/train-images-idx3-ubyte 0.1 true 3 784 100 10 1500 2 small_100.model
 
 [2024-09-18 23:32:59]: Starting to load MNIST labels
 [2024-09-18 23:32:59]: Finished loading MNIST labels

--- a/src/MNIST_Images.c
+++ b/src/MNIST_Images.c
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-18
+ * @version: 2024-09-30
  *
  * General Notes: MNIST file reading inspired by: https://github.com/AndrewCarterUK/mnist-neural-network-plain-c/blob/master/mnist_file.c 
  *
@@ -31,7 +31,7 @@ MNIST_Images* init_MNIST_images(const char* path) {
     if (images_file == NULL) {
 
         if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Unable to open the path to the MNIST imagess\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // We want to read in four values at once here to avoid using fread again and again
@@ -43,7 +43,7 @@ MNIST_Images* init_MNIST_images(const char* path) {
         if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Unable to read headers from MNIST images file\n"); }
 
         fclose(images_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // The first entry in the array is used for the magic number; the second is for the number of items
@@ -52,7 +52,7 @@ MNIST_Images* init_MNIST_images(const char* path) {
         if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Mistmatched magic number in the MNIST images file header\n"); }
         
         fclose(images_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Validate the image size matches what we're expecting
@@ -62,7 +62,7 @@ MNIST_Images* init_MNIST_images(const char* path) {
             map_uint32(image_buffer[2]), map_uint32(image_buffer[3])); }
 
         fclose(images_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Allocate the memory to store the images
@@ -73,7 +73,7 @@ MNIST_Images* init_MNIST_images(const char* path) {
         if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory to create MNIST_Images\n"); }
         
         fclose(images_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Persist the flipped number of items before reading in
@@ -95,7 +95,7 @@ MNIST_Images* init_MNIST_images(const char* path) {
             if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for image number %u\n", i); }
 
             fclose(images_file);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         // For each expected pixel, grab the value and store it in the pixelMatrix
@@ -108,7 +108,7 @@ MNIST_Images* init_MNIST_images(const char* path) {
                     if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Error reading pixel data @ index (%u, %zu, %zu)\n", i,  j, k); }
 
                     fclose(images_file);
-                    return NULL;
+                    exit(EXIT_FAILURE);
                 }
 
                 // Copy the value of the pixel intensity to the newly created pixelMatrix
@@ -125,18 +125,18 @@ MNIST_Images* init_MNIST_images(const char* path) {
     return target;
 }
 
-pixelMatrix* MNIST_Images_get(const struct MNIST_Images* target, uint32_t index) {
+pixelMatrix* MNIST_Images_get(const MNIST_Images* target, uint32_t index) {
     
     if (target == NULL) {
 
         if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Invalid MNIST_Images pointer provided. Returning NULL\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (index >= target->num_images) {
 
         if (MNIST_IMAGES_DEBUG) { fprintf(stderr, "ERR: Invalid image index provided. Got %u and expecting max %u\n", index, target->num_images); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     return target->images[index];

--- a/src/MNIST_Labels.c
+++ b/src/MNIST_Labels.c
@@ -25,7 +25,7 @@ MNIST_Labels* init_MNIST_labels(const char* path) {
     if (label_file == NULL) {
 
         if (MNIST_LABELS_DEBUG) { fprintf(stderr, "ERR: Unable to open the path to the MNIST labels\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // We want to read in two values at once here to avoid using fread twice
@@ -37,7 +37,7 @@ MNIST_Labels* init_MNIST_labels(const char* path) {
         if (MNIST_LABELS_DEBUG) { fprintf(stderr, "ERR: Unable to read headers from MNIST label file\n"); }
 
         fclose(label_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // The first entry in the array is used for the magic number; the second is for the number of items
@@ -46,7 +46,7 @@ MNIST_Labels* init_MNIST_labels(const char* path) {
         if (MNIST_LABELS_DEBUG) { fprintf(stderr, "ERR: Mistmatched magic number in the MNIST label file header\n"); }
         
         fclose(label_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Allocate the memory to store the labels
@@ -57,7 +57,7 @@ MNIST_Labels* init_MNIST_labels(const char* path) {
         if (MNIST_LABELS_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory to create MNIST_Labels\n"); }
         
         fclose(label_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Persist the flipped number of items before reading in
@@ -72,7 +72,7 @@ MNIST_Labels* init_MNIST_labels(const char* path) {
 
         free(target);
         fclose(label_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Read the labels from the file
@@ -83,7 +83,7 @@ MNIST_Labels* init_MNIST_labels(const char* path) {
         free(target->labels);
         free(target);
         fclose(label_file);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Ensure we clean up the file reference
@@ -95,18 +95,18 @@ MNIST_Labels* init_MNIST_labels(const char* path) {
     return target;
 }
 
-uint8_t MNIST_Labels_get(const struct MNIST_Labels* target, uint32_t index) {
+uint8_t MNIST_Labels_get(const MNIST_Labels* target, uint32_t index) {
 
     if (target == NULL) {
 
         if (MNIST_LABELS_DEBUG) { fprintf(stderr, "ERR: Invalid MNIST_Labels pointer provided. Returning 0\n"); }
-        return (uint8_t)0;
+        exit(EXIT_FAILURE);
     }
 
     if (index >= target->num_labels) {
 
         if (MNIST_LABELS_DEBUG) { fprintf(stderr, "ERR: Invalid label index provided. Got %u and expecting max %u\n", index, target->num_labels); }
-        return (uint8_t)0;
+        exit(EXIT_FAILURE);
     }
 
     return target->labels[index];

--- a/src/Matrix.c
+++ b/src/Matrix.c
@@ -32,7 +32,7 @@
  * @param target_col Column to access / set
  * @returns True if record exists, False if it does not
  */
-bool MATRIX_METHOD(exists)(const struct MATRIX_TYPE_NAME *target, size_t target_row, size_t target_col) {
+bool MATRIX_METHOD(exists)(const MATRIX_TYPE_NAME *target, size_t target_row, size_t target_col) {
     
     // Verify that the target is not NULL
     if (target == NULL) {
@@ -138,7 +138,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(dot)(const MATRIX_TYPE_NAME *self, const MATRIX_
     if (self == NULL || target == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Self or target Matrix is NULL. Cannot calculate dot product\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (self->num_cols != target->num_rows) {
@@ -149,7 +149,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(dot)(const MATRIX_TYPE_NAME *self, const MATRIX_
             fprintf(stderr, "First Matrix is [%zu x %zu], second is [%zu x %zu]\n",
                 self->num_rows, self->num_cols, target->num_rows, target->num_cols);
         }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(self->num_rows, target->num_cols);
@@ -180,13 +180,13 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(dot)(const MATRIX_TYPE_NAME *self, const MATRIX_
  * @param target_row The row we want to extract
  * @return Returns a "vector" / array of the Matrix type
  */
-MATRIX_TYPE_NAME *MATRIX_METHOD(get_row)(const struct MATRIX_TYPE_NAME *target, size_t target_row) {
+MATRIX_TYPE_NAME *MATRIX_METHOD(get_row)(const MATRIX_TYPE_NAME *target, size_t target_row) {
 
     // Ensure that the target row exists inside of a valid Matrix
     if (!MATRIX_METHOD(exists)(target, target_row, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix / row provided to get_row\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(1, target->num_cols);
@@ -205,13 +205,13 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(get_row)(const struct MATRIX_TYPE_NAME *target, 
  * @param target_col The col we want to extract
  * @return A new Matrix containing the contents of the target column. Must be cleaned up after
  */
-MATRIX_TYPE_NAME *MATRIX_METHOD(get_col)(const struct MATRIX_TYPE_NAME *target, size_t target_col) {
+MATRIX_TYPE_NAME *MATRIX_METHOD(get_col)(const MATRIX_TYPE_NAME *target, size_t target_col) {
 
     // Ensure that the target col exists inside of a valid Matrix
     if (!MATRIX_METHOD(exists)(target, 0, target_col)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix / col provided to get_col\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(target->num_rows, 1);
@@ -233,7 +233,7 @@ void MATRIX_METHOD(print)(const MATRIX_TYPE_NAME *target) {
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to print\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -261,7 +261,7 @@ MATRIX_TYPE MATRIX_METHOD(max)(const MATRIX_TYPE_NAME *target) {
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to max\n"); }
-        return (MATRIX_TYPE)0;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE current_max = target->get(target, 0, 0);
@@ -288,7 +288,7 @@ MATRIX_TYPE MATRIX_METHOD(min)(const MATRIX_TYPE_NAME *target) {
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to max\n"); }
-        return (MATRIX_TYPE)0;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE current_min = target->get(target, 0, 0);
@@ -317,7 +317,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(flatten)(const MATRIX_TYPE_NAME *target, Vector_
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to flatten\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = NULL;
@@ -334,7 +334,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(flatten)(const MATRIX_TYPE_NAME *target, Vector_
     if (result == NULL) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for flattened Matrix\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     size_t index = 0;
@@ -371,7 +371,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(transpose)(const MATRIX_TYPE_NAME *target) {
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to transpose\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(target->num_cols, target->num_rows);
@@ -379,7 +379,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(transpose)(const MATRIX_TYPE_NAME *target) {
     if (result == NULL) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for the transpose operation\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -405,13 +405,13 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(add)(const MATRIX_TYPE_NAME *self, const MATRIX_
     if (self == NULL || target == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Self or target Matrix is NULL. Cannot add\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (self->num_cols != target->num_cols || self->num_rows != target->num_rows) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Matrix dimension mismatch. Cannot add\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(self->num_rows, self->num_cols);
@@ -419,7 +419,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(add)(const MATRIX_TYPE_NAME *self, const MATRIX_
     if (result == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for addition Matrix result\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < self->num_rows; ++i) {
@@ -443,13 +443,13 @@ void MATRIX_METHOD(add_o)(const MATRIX_TYPE_NAME *self, const MATRIX_TYPE_NAME *
     if (self == NULL || target == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Self or target Matrix is NULL. Cannot add_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     if (self->num_cols != target->num_cols || self->num_rows != target->num_rows) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Matrix dimension mismatch. Cannot add_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < self->num_rows; ++i) {
@@ -472,13 +472,13 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(subtract)(const MATRIX_TYPE_NAME *self, const MA
     if (self == NULL || target == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Self or target Matrix is NULL. Cannot subtract\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (self->num_cols != target->num_cols || self->num_rows != target->num_rows) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Matrix dimension mismatch. Cannot subtract\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(self->num_rows, self->num_cols);
@@ -486,7 +486,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(subtract)(const MATRIX_TYPE_NAME *self, const MA
     if (result == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for subtraxtion Matrix result\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < self->num_rows; ++i) {
@@ -510,13 +510,13 @@ void MATRIX_METHOD(subtract_o)(const MATRIX_TYPE_NAME *self, const MATRIX_TYPE_N
     if (self == NULL || target == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Self or target Matrix is NULL. Cannot subtract_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     if (self->num_cols != target->num_cols || self->num_rows != target->num_rows) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Matrix dimension mismatch. Cannot subtract_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < self->num_rows; ++i) {
@@ -539,7 +539,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(scale)(const MATRIX_TYPE_NAME *target, MATRIX_TY
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to scale\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(target->num_rows, target->num_cols);
@@ -547,7 +547,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(scale)(const MATRIX_TYPE_NAME *target, MATRIX_TY
     if (result == NULL) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for the scale operation\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -571,7 +571,7 @@ void MATRIX_METHOD(scale_o)(const MATRIX_TYPE_NAME *target, MATRIX_TYPE scalar) 
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to scale_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -596,7 +596,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(add_scalar)(const MATRIX_TYPE_NAME *target, MATR
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to add_scalar\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(target->num_rows, target->num_cols);
@@ -604,7 +604,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(add_scalar)(const MATRIX_TYPE_NAME *target, MATR
     if (result == NULL) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for the add scalar operation\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -628,7 +628,7 @@ void MATRIX_METHOD(add_scalar_o)(const MATRIX_TYPE_NAME *target, MATRIX_TYPE sca
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to add_scalar_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -653,7 +653,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(apply)(const MATRIX_TYPE_NAME *target, MATRIX_TY
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to apply\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(target->num_rows, target->num_cols);
@@ -661,7 +661,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(apply)(const MATRIX_TYPE_NAME *target, MATRIX_TY
     if (result == NULL) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for the apply operation\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -685,7 +685,7 @@ void MATRIX_METHOD(apply_o)(const MATRIX_TYPE_NAME *target, MATRIX_TYPE (*func)(
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to apply_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -710,16 +710,16 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(apply_second)(const MATRIX_TYPE_NAME *target, MA
 
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
-        if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to apply\n"); }
-        return NULL;
+        if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to apply_second\n"); }
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(target->num_rows, target->num_cols);
 
     if (result == NULL) {
 
-        if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for the apply operation\n"); }
-        return NULL;
+        if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for the apply_second operation\n"); }
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -744,7 +744,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(multiply)(const MATRIX_TYPE_NAME *self, const MA
     if (self == NULL || target == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Self or target Matrix is NULL. Cannot multiply\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (self->num_cols != target->num_cols || self->num_rows != target->num_rows) {
@@ -752,7 +752,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(multiply)(const MATRIX_TYPE_NAME *self, const MA
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Matrix dimension mismatch. Cannot multiply. [%zu x %zu] != [%zu x %zu]\n",
             self->num_rows, self->num_cols, target->num_rows, target->num_cols); }
         
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(self->num_rows, self->num_cols);
@@ -760,7 +760,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(multiply)(const MATRIX_TYPE_NAME *self, const MA
     if (result == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for multiplication Matrix result\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < self->num_rows; ++i) {
@@ -784,7 +784,7 @@ void MATRIX_METHOD(multiply_o)(const MATRIX_TYPE_NAME *self, const MATRIX_TYPE_N
     if (self == NULL || target == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Self or target Matrix is NULL. Cannot multiply_o\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     if (self->num_cols != target->num_cols || self->num_rows != target->num_rows) {
@@ -792,7 +792,7 @@ void MATRIX_METHOD(multiply_o)(const MATRIX_TYPE_NAME *self, const MATRIX_TYPE_N
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Matrix dimension mismatch. Cannot multiply_o. [%zu x %zu] != [%zu x %zu]\n",
             self->num_rows, self->num_cols, target->num_rows, target->num_cols); }
         
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < self->num_rows; ++i) {
@@ -816,7 +816,7 @@ void MATRIX_METHOD(populate)(MATRIX_TYPE_NAME *target, MATRIX_TYPE value) {
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to populate\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -838,7 +838,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(copy)(const MATRIX_TYPE_NAME *target) {
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to copy\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE_NAME *result = MATRIX_METHOD(allocate)(target->num_rows, target->num_cols);
@@ -846,7 +846,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(copy)(const MATRIX_TYPE_NAME *target) {
     if (result == NULL) { 
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for copying Matrix\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -870,7 +870,7 @@ MATRIX_TYPE MATRIX_METHOD(sum)(const MATRIX_TYPE_NAME *target) {
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to sum\n"); }
-        return (MATRIX_TYPE)0;
+        exit(EXIT_FAILURE);
     }
 
     MATRIX_TYPE running_sum = 0;
@@ -898,7 +898,7 @@ size_t MATRIX_METHOD(max_idx)(const MATRIX_TYPE_NAME *target, Vector_Orientation
     if (!MATRIX_METHOD(exists)(target, 0, 0)) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Invalid Matrix provided to max_idx\n"); }
-        return (MATRIX_TYPE)0;
+        exit(EXIT_FAILURE);
     }
 
     size_t max_index = 0;
@@ -955,7 +955,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(allocate)(size_t desired_rows, size_t desired_co
     if (target == NULL) {
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate Matrix of size %zu x %zu\n", desired_rows, desired_cols); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Allocate the proper number of rows -- i.e. an array of arrays
@@ -965,7 +965,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(allocate)(size_t desired_rows, size_t desired_co
 
         if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to data array in Matrix of size %zu x %zu\n", desired_rows, desired_cols); }
         
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Iterate over the rows and start allocating the proper columns
@@ -976,7 +976,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(allocate)(size_t desired_rows, size_t desired_co
         if (target->data[i] == NULL) {
 
             if (MATRIX_DEBUG) { fprintf(stderr, "ERR: Unable to allocate row in Matrix of size %zu x %zu\n", desired_rows, desired_cols); }
-            return NULL;
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/src/Neural_Network.c
+++ b/src/Neural_Network.c
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-26
+ * @version: 2024-09-30
  *
  * General Notes:
  *
@@ -20,7 +20,7 @@
 // Include the type of Matrix that we want to use
 #define MATRIX_TYPE_NAME floatMatrix
 #define MATRIX_TYPE float
-#define MATRIX_STRING "%1.28f"
+#define MATRIX_STRING "%1.10f"
 #include "Matrix.c"
 
 void Neural_Network_Layer_clear(Neural_Network_Layer* target) {
@@ -62,7 +62,7 @@ Neural_Network_Layer* init_Neural_Network_Layer(size_t num_neurons, size_t previ
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for new Neural_Network_Layer\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Persist the number of neurons
@@ -91,7 +91,7 @@ Neural_Network_Layer* init_Neural_Network_Layer(size_t num_neurons, size_t previ
     if (target->weights == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for weights in Neural_Network_Layer\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (target->biases == NULL) {
@@ -99,7 +99,7 @@ Neural_Network_Layer* init_Neural_Network_Layer(size_t num_neurons, size_t previ
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for biases in Neural_Network_Layer\n"); }
 
         target->weights->clear(target->weights);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < num_neurons; ++i) {
@@ -132,7 +132,7 @@ floatMatrix* Neural_Network_Layer_normalize_layer(const floatMatrix* target) {
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid floatMatrix provided to normalize\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     float mean = target->sum(target) / target->num_rows;
@@ -164,7 +164,7 @@ Neural_Network_Layer* Neural_Network_Layer_copy(const Neural_Network_Layer* self
     if (self == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural Network Layer provided to copy\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Take advantage of the import function to just allocate memory and setup the function pointers
@@ -188,7 +188,7 @@ floatMatrix* Neural_Network_predict(const Neural_Network* self, const pixelMatri
     if (self == NULL || image == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural_Network or pixelMatrix provided to predict\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Create a floatMatrix to store the pixelMatrix data
@@ -207,7 +207,7 @@ floatMatrix* Neural_Network_predict(const Neural_Network* self, const pixelMatri
     if (outputs == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for output storage in predict\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 1; i < self->num_layers; ++i) {
@@ -251,7 +251,7 @@ void* Neural_Network_threaded_predict(void* thread_void) {
     if (thread_void == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Threaded_Inference_Results provided to batch_predict\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     Threaded_Inference_Result* thread = (Threaded_Inference_Result*)thread_void;
@@ -280,7 +280,7 @@ floatMatrix* Neural_Network_sigmoid_prime(const floatMatrix* target) {
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid floatMatrix provided to sigmoid_prime\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     floatMatrix* one = floatMatrix_allocate(target->num_rows, target->num_cols);
@@ -302,7 +302,7 @@ floatMatrix* Neural_Network_softmax(const floatMatrix* target) {
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid floatMatrix provided to softmax\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     float total = 0;
@@ -320,7 +320,7 @@ floatMatrix* Neural_Network_softmax(const floatMatrix* target) {
     if (result == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for new floatMatrix in softmax\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_rows; ++i) {
@@ -339,7 +339,7 @@ floatMatrix* Neural_Network_convert_pixelMatrix(const pixelMatrix* pixels) {
     if (pixels == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid pixelMatrix provided for conversion\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     floatMatrix* target = floatMatrix_allocate(pixels->num_rows, pixels->num_cols);
@@ -347,7 +347,7 @@ floatMatrix* Neural_Network_convert_pixelMatrix(const pixelMatrix* pixels) {
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate floatMatrix for pixelMatrix conversion\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < pixels->num_rows; ++i) {
@@ -368,7 +368,7 @@ floatMatrix* Neural_Network_create_label(uint8_t label) {
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for label floatMatrix\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Zero out the values of the floatMatrix
@@ -385,6 +385,7 @@ void Neural_Network_training_predict(Neural_Network* self, const floatMatrix* fl
     if (self == NULL || flat_image == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural_Network or floatMatrix provided to training_predict\n"); }
+        exit(EXIT_FAILURE);
     }
 
     // Store the input layer's output (aka the flattened image)
@@ -425,6 +426,7 @@ void Neural_Network_train(Neural_Network* self, const pixelMatrix* image, uint8_
     if (self == NULL || image == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural_Network or pixelMatrix provided to train\n"); }
+        exit(EXIT_FAILURE);
     }
 
     /* Do inference and store all the layer outputs in the respective layers */
@@ -492,6 +494,10 @@ void Neural_Network_train(Neural_Network* self, const pixelMatrix* image, uint8_
         self->layers[i]->weights = self->layers[i]->new_weights;
         self->layers[i]->new_weights = NULL;
 
+        // Update the biases too, now that we're done with the errors we can scale by learning rate before cleaning up
+        self->layers[i]->errors->scale_o(self->layers[i]->errors, self->learning_rate);
+        self->layers[i]->biases->add_o(self->layers[i]->biases, self->layers[i]->errors);
+
         self->layers[i]->outputs->clear(self->layers[i]->outputs);
         self->layers[i]->outputs = NULL;
 
@@ -514,8 +520,7 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
     if (self == NULL || images == NULL || labels == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural Network, MNIST_Images, or MNIST_Labels provided to batch_train\n"); }
-
-        return;
+        exit(EXIT_FAILURE);
     }
 
     // Define variables we're going to use throughout the loops
@@ -526,12 +531,15 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
     floatMatrix* sigmoid_prime = NULL;
     floatMatrix* transpose = NULL;
     floatMatrix* outputs = NULL;
+    floatMatrix* ones = NULL;
     floatMatrix** nabla_w = calloc(self->num_layers, sizeof(floatMatrix*));
+    floatMatrix** nabla_b = calloc(self->num_layers, sizeof(floatMatrix*));
 
     // Initialize values across nabla_w
     for (size_t i = 1; i < self->num_layers; ++i) {
 
         nabla_w[i] = NULL;
+        nabla_b[i] = NULL;
     }
 
     // Information about the batches
@@ -551,6 +559,10 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
             inputs = floatMatrix_allocate(MNIST_IMAGE_SIZE, final_batch_size);
             outputs = floatMatrix_allocate(MNIST_LABELS, final_batch_size);
             outputs->populate(outputs, 0);
+
+            // Set up a Matrix of ones for getting the bias error
+            ones = floatMatrix_allocate(final_batch_size, 1);
+            ones->populate(ones, 1);
 
             // Insert the image data into the larger input Matrix
             for (size_t j = 0; j < final_batch_size; ++j) {
@@ -588,6 +600,10 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
             inputs = floatMatrix_allocate(MNIST_IMAGE_SIZE, batch_size);
             outputs = floatMatrix_allocate(MNIST_LABELS, batch_size);
             outputs->populate(outputs, 0);
+
+            // Set up a Matrix of ones for getting the bias error
+            ones = floatMatrix_allocate(batch_size, 1);
+            ones->populate(ones, 1);
 
             // Insert the image data into the larger input Matrix
             for (size_t j = 0; j < batch_size; ++j) {
@@ -653,6 +669,9 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
             // Get the dot product of the transposed outputs and the errors * sigmoid
             nabla_w[j] = sigmoid_prime->dot(sigmoid_prime, transpose);
 
+            // Get the sum of the errors for processing later
+            nabla_b[j] = self->layers[j]->errors->dot(self->layers[j]->errors, ones);
+
             sigmoid_prime->clear(sigmoid_prime);
             transpose->clear(transpose);
         }
@@ -667,11 +686,13 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
 
                 // Divide the sum of deltas per layer by the batch size and multiply by learning rate
                 nabla_w[j]->scale_o(nabla_w[j], self->learning_rate / (float)final_batch_size);
+                nabla_b[j]->scale_o(nabla_b[j], self->learning_rate / (float)final_batch_size);
 
             }
             else {
 
                 nabla_w[j]->scale_o(nabla_w[j], self->learning_rate / (float)batch_size);
+                nabla_b[j]->scale_o(nabla_b[j], self->learning_rate / (float)batch_size);
             }
 
             // Add the processed changes to the original weights
@@ -693,8 +714,12 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
 
             self->layers[j]->biases->clear(self->layers[j]->biases);
             self->layers[j]->biases = expanded_bias;
+            self->layers[j]->biases->add_o(self->layers[j]->biases, nabla_b[j]);
 
             expanded_bias = NULL;
+
+            nabla_b[j]->clear(nabla_b[j]);
+            nabla_b[j] = NULL;
         }
 
         // Clean up the first layer's 'output', i.e. the image Matrix
@@ -710,9 +735,13 @@ void Neural_Network_batch_train(Neural_Network* self, const MNIST_Images* images
 
         outputs->clear(outputs);
         outputs = NULL;
+
+        ones->clear(ones);
+        ones = NULL;
     }
 
     free(nabla_w);
+    free(nabla_b);
 }
 
 void Neural_Network_save(const Neural_Network* self, bool include_biases, const char* filename) {
@@ -720,7 +749,7 @@ void Neural_Network_save(const Neural_Network* self, bool include_biases, const 
     if (self == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural Network to save\n"); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     FILE* model = fopen(filename, "w");
@@ -728,7 +757,7 @@ void Neural_Network_save(const Neural_Network* self, bool include_biases, const 
     if (model == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to open file %s to save model\n", filename); }
-        return;
+        exit(EXIT_FAILURE);
     }
 
     uint32_t header_magic = NN_HEADER_MAGIC;
@@ -817,7 +846,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
     if (filename == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid char* for filename provided to import\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Open the path to the model file
@@ -826,7 +855,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
     if (model == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read model file\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     uint32_t header_magic = 0;
@@ -837,7 +866,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read header info from model\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (header_magic != NN_HEADER_MAGIC) {
@@ -845,7 +874,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid magic number in model header\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Get ready to get the learning rate for the model
@@ -856,7 +885,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read learning rate from model\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Check to see if biases were included in the model, either 0 for no, or 1 for yes
@@ -867,7 +896,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read bias info from model\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Get the number of layers in the model
@@ -878,7 +907,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read number of layers from model\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Allocate an array of size_t to get the size of the layers
@@ -889,7 +918,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read layer info\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Setup a buffer to grab values from the file without making new variables
@@ -900,7 +929,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read weight magic number\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (buffer != NN_WEIGHTS_MAGIC) {
@@ -908,7 +937,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid weight magic number\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Once we have all the information, create a new Neural Network
@@ -919,7 +948,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for the Neural Network\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Much of this should look the same as allocate_Neural_Network
@@ -942,7 +971,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for layers\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Special processing for the input layer, since it has no weights or biases
@@ -965,7 +994,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Error reading model layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         if (buffer != NN_WEIGHT_BEGIN) {
@@ -973,7 +1002,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid start weights value for layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         // Allocate a new floatMatrix for the weights of this layer
@@ -988,7 +1017,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
                     if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Error reading (%zu, %zu) for model layer %zu\n", j, k, i); }
 
                     fclose(model);
-                    return NULL;
+                    exit(EXIT_FAILURE);
                 }
 
                 // Copy the float value of the weight to the new floatMatrix
@@ -1001,7 +1030,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Error reading end of model layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         if (buffer != NN_WEIGHT_END) {
@@ -1009,7 +1038,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid end weights value for layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         // Persist the weights to the layer directly
@@ -1032,7 +1061,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to read bias magic number\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     if (buffer != NN_BIASES_MAGIC) {
@@ -1040,7 +1069,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid bias magic number\n"); }
 
         fclose(model);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     // Store the layer's biases somewhere
@@ -1053,7 +1082,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Error reading bias for layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         if (buffer != NN_BIAS_BEGIN) {
@@ -1061,7 +1090,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid start bias value for layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         current_biases = floatMatrix_allocate(layer_info[i], 1);
@@ -1074,7 +1103,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
                 if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Error reading (%zu, 0) for bias layer %zu\n", j, i); }
 
                 fclose(model);
-                return NULL;
+                exit(EXIT_FAILURE);
             }
 
             current_biases->set(current_biases, j, 0, float_buffer);
@@ -1085,7 +1114,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Error reading end of bias layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         if (buffer != NN_BIAS_END) {
@@ -1093,7 +1122,7 @@ Neural_Network* import_Neural_Network(const char* filename) {
             if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid end biases value for layer %zu\n", i); }
 
             fclose(model);
-            return NULL;
+            exit(EXIT_FAILURE);
         }
 
         target->layers[i]->biases = current_biases;
@@ -1112,7 +1141,7 @@ Neural_Network* init_Neural_Network(size_t num_layers, const size_t* layer_info,
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for new Neural_Network\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     target->num_layers = num_layers;
@@ -1143,7 +1172,7 @@ Neural_Network* Neural_Network_copy(const Neural_Network* self) {
     if (self == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural Network provided to copy\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     Neural_Network* target = malloc(sizeof(Neural_Network));
@@ -1151,7 +1180,7 @@ Neural_Network* Neural_Network_copy(const Neural_Network* self) {
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for Neural Network copy\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     target->num_layers = self->num_layers;
@@ -1164,7 +1193,7 @@ Neural_Network* Neural_Network_copy(const Neural_Network* self) {
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate memory for Neural Network Layer array in copy\n"); }
 
         free(target);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     for (size_t i = 0; i < target->num_layers; ++i) {
@@ -1200,7 +1229,7 @@ floatMatrix* Neural_Network_expand_bias(const floatMatrix* current_bias, size_t 
     if (current_bias == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid bias Matrix provided to expand_bias\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     floatMatrix* expanded = floatMatrix_allocate(current_bias->num_rows, batch_size);
@@ -1225,7 +1254,7 @@ Threaded_Inference_Result* init_Threaded_Inference_Result(const Neural_Network* 
     if (nn == NULL || images == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Invalid Neural Network or MNIST_Images passed to init_Threaded_Inference_Result\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     Threaded_Inference_Result* target = malloc(sizeof(Threaded_Inference_Result));
@@ -1233,7 +1262,7 @@ Threaded_Inference_Result* init_Threaded_Inference_Result(const Neural_Network* 
     if (target == NULL) {
 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate Threaded_Inference_Result\n"); }
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     target->nn = nn;
@@ -1248,7 +1277,7 @@ Threaded_Inference_Result* init_Threaded_Inference_Result(const Neural_Network* 
         if (NEURAL_NETWORK_DEBUG) { fprintf(stderr, "ERR: Unable to allocate floatMatrix for Threaded_Inference_Result\n"); }
 
         free(target);
-        return NULL;
+        exit(EXIT_FAILURE);
     }
 
     target->clear = Threaded_Inference_Result_clear;

--- a/src/include/MNIST_Images.h
+++ b/src/include/MNIST_Images.h
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-16
+ * @version: 2024-09-30
  *
  * General Notes: MNIST file reading inspired by: https://github.com/AndrewCarterUK/mnist-neural-network-plain-c/blob/master/mnist_file.c 
  *
@@ -74,7 +74,7 @@ MNIST_Images* init_MNIST_images(const char* path);
  * @param target The MNIST_Images instance to fetch from
  * @param index The number of the image / pixelMatrix we want to fetch
  */
-pixelMatrix* MNIST_Images_get(const struct MNIST_Images* target, uint32_t index);
+pixelMatrix* MNIST_Images_get(const MNIST_Images* target, uint32_t index);
 
 /**
  * Method to clean up a MNSIST_Images instance and free memory

--- a/src/include/MNIST_Labels.h
+++ b/src/include/MNIST_Labels.h
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-15
+ * @version: 2024-09-30
  *
  * General Notes: MNIST file reading inspired by: https://github.com/AndrewCarterUK/mnist-neural-network-plain-c/blob/master/mnist_file.c 
  *
@@ -66,7 +66,7 @@ MNIST_Labels* init_MNIST_labels(const char* path);
  * @param target The MNIST_Labels instance to fetch from
  * @param index The number of the label we want to fetch
  */
-uint8_t MNIST_Labels_get(const struct MNIST_Labels* target, uint32_t index);
+uint8_t MNIST_Labels_get(const MNIST_Labels* target, uint32_t index);
 
 /**
  * Clean up a MNIST_Labels instance and free associated memorry

--- a/src/include/Matrix.h
+++ b/src/include/Matrix.h
@@ -8,10 +8,8 @@
  *                                                                                                               
  * Project: Matrix Library in C
  * @author : Samuel Andersen
- * @version: 2024-09-22
+ * @version: 2024-09-30
  *
- * Note: see upstream for Matrix @ https://github.com/andersensam/Matrix
- * 
  */
 
 /* Include the standard things we want for the Matrix header before doing the part that repeats */
@@ -273,7 +271,7 @@ typedef struct MATRIX_TYPE_NAME {
  * @param target_col Column to access / set
  * @returns True if record exists, False if it does not
  */
-bool MATRIX_METHOD(exists)(const struct MATRIX_TYPE_NAME *target, size_t target_row, size_t target_col);
+bool MATRIX_METHOD(exists)(const MATRIX_TYPE_NAME *target, size_t target_row, size_t target_col);
 
 /**
  * Function to clean up a Matrix if it's no longer needed
@@ -313,7 +311,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(dot)(const MATRIX_TYPE_NAME *self, const MATRIX_
  * @param target_row The row we want to extract
  * @return Returns a "vector" / array of the Matrix type
  */
-MATRIX_TYPE_NAME *MATRIX_METHOD(get_row)(const struct MATRIX_TYPE_NAME *target, size_t target_row);
+MATRIX_TYPE_NAME *MATRIX_METHOD(get_row)(const MATRIX_TYPE_NAME *target, size_t target_row);
 
 /**
  * Get a col of a Matrix
@@ -321,7 +319,7 @@ MATRIX_TYPE_NAME *MATRIX_METHOD(get_row)(const struct MATRIX_TYPE_NAME *target, 
  * @param target_col The col we want to extract
  * @return A new Matrix containing the contents of the target column. Must be cleaned up after
  */
-MATRIX_TYPE_NAME *MATRIX_METHOD(get_col)(const struct MATRIX_TYPE_NAME *target, size_t target_col);
+MATRIX_TYPE_NAME *MATRIX_METHOD(get_col)(const MATRIX_TYPE_NAME *target, size_t target_col);
 
 /**
  * Print the entire Matrix

--- a/src/include/main.h
+++ b/src/include/main.h
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-22
+ * @version: 2024-09-30
  *
  * General Notes:
  *
@@ -20,6 +20,9 @@
 
 /* Configure multithreading */
 #define INFERENCE_MAX_THREADS 4
+
+/* Show epochs when 1, does not when 0 */
+#define SHOW_EPOCH 0
 
 /* Standard dependencies */
 #include <stdio.h>
@@ -45,11 +48,27 @@
  * @param nn_config An array of size_t containing the number of neurons in each layer
  * @param learning_rate Hyperparameter learning rate
  * @param generate_biases Boolean of whether or not to create random biases
- * @param model_path Path to save the model once it has been trained
  * @param num_training_images Number of training images to train on
+ * @param epochs Number of epochs to run
+ * @param model_path Path to save the model once it has been trained
  */
 void train_new_model(const char* labels_path, const char* images_path, size_t num_layers, const size_t* nn_config,
-    float learning_rate, bool generate_biases, const char* model_path, size_t num_training_images);
+    float learning_rate, bool generate_biases, size_t num_training_images, size_t epochs, const char* model_path);
+
+/**
+ * Function to train a new model from scratch using batching, saving it to a file when complete
+ * @param labels_path Path to the labels for the data
+ * @param images_path Path to the images
+ * @param num_layers Number of layers to create in the network
+ * @param nn_config An array of size_t containing the number of neurons in each layer
+ * @param learning_rate Hyperparameter learning rate
+ * @param num_training_images Number of training images to train on
+ * @param batch_size Batch size to use, does not have to divide evenly over dataset
+ * @param epochs Number of epochs to run
+ * @param model_path Path to save the model once it has been trained
+ */
+void train_new_model_batched(const char* labels_path, const char* images_path, size_t num_layers, const size_t* nn_config,
+    float learning_rate, bool generate_biases, size_t num_training_images, size_t batch_size, size_t epochs, const char* model_path);
 
 /**
  * Function to perform inference on a pretrained model

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-18
+ * @version: 2024-09-30
  *
  * General Notes:
  *
@@ -18,8 +18,6 @@
 #include "include/utils.h"
 
 float sigmoid(float z) {
-
-    //printf("sigmoid input %f\n", z);
 
     return 1.0f / (1 + exp(-1 * z));
 }


### PR DESCRIPTION
Change `return` behavior when errors occur, exiting instead. Also implement updating of biases (not originally enabled). Change some definitions of `struct X*` to be `X*`. Cleanup and update README