### PR TITLE
Fix typo + refactor from `util.c` --> `Neural_Network.c`

### DIFF
--- a/src/include/Neural_Network.h
+++ b/src/include/Neural_Network.h
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-25
+ * @version: 2024-10-07
  *
  * General Notes:
  *
@@ -19,6 +19,11 @@
 #define NEURAL_NETWORK_H
 
 #define NEURAL_NETWORK_DEBUG 1
+
+/* Cost Function and Derivative Definition */
+#define NEURAL_NETWORK_ACTIVATION Neural_Network_sigmoid
+#define NEURAL_NETWORK_COST_DERIVATIVE Neural_Network_sigmoid_prime
+#define NEURAL_NETWORK_OUTPUT_DELTA Neural_Network_sigmoid_delta
 
 /* Markers to help with loading / saving Neural Networks */
 #define NN_HEADER_MAGIC 0x0000AA00
@@ -207,6 +212,28 @@ typedef struct Neural_Network {
     struct Neural_Network* (*copy)(const struct Neural_Network* self);
 
     /**
+     * The cost function to apply. This is a placeholder, using the function defined in the header above
+     * This should be used with Matrix->apply
+     * @param z Float to apply the cost function to
+     * @returns Returns a float of the cost function.
+     */
+    float (*activation)(float z);
+
+    /**
+     * The derivative of the cost function to apply
+     * @param target A floatMatrix to apply calculate the derivative of
+     */
+    floatMatrix* (*cost_derivative)(const floatMatrix* target);
+
+    /**
+     * Delta placeholder function
+     * @param actual Actual value(s)
+     * @param output Output(s) from the final layer
+     * @returns Returns a floatMatrix with the delta (however that is calculate for your activation)
+     */
+    floatMatrix* (*delta)(const floatMatrix* actual, const floatMatrix* output);
+
+    /**
      * Cleans up a Neural Network instance
      * @param target The Neural Network to clean up
      */
@@ -245,11 +272,26 @@ floatMatrix* Neural_Network_predict(const Neural_Network* self, const pixelMatri
 void* Neural_Network_threaded_predict(void* thread_void);
 
 /**
+ * Calculate the sigmoid of a given float
+ * @param z The float value we want to calculate the sigmoid of
+ * @returns Returns a float, containing the sigmoid
+ */
+float Neural_Network_sigmoid(float z);
+
+/**
  * Calculate the sigmoid prime of a Matrix
  * @param target The Matrix to calculate the sigmoid prime of -- this should already have sigmoid applied to it
  * @returns Returns a new Matrix of sigmoid prime values
  */
 floatMatrix* Neural_Network_sigmoid_prime(const floatMatrix* target);
+
+/**
+ * Calculate the error / delta for sigmoid output layers
+ * @param actual Actual value(s)
+ * @param output The output(s) from the NN
+ * @returns Returns a floatMatrix containing `actual - output`
+ */
+floatMatrix* Neural_Network_sigmoid_delta(const floatMatrix* actual, const floatMatrix* output);
 
 /**
  * Calculate the softmax of a Matrix

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-17
+ * @version: 2024-10-04
  *
  * General Notes:
  *
@@ -28,13 +28,6 @@
 /* Local dependencies */
 
 /* Definitions */
-
-/**
- * Calculate the sigmoid of a given float
- * @param z The float value we want to calculate the sigmoid of
- * @returns Returns a float, containing the sigmoid
- */
-float sigmoid(float z);
 
 /**
  * Convert from the big endian format in the dataset if we're on a little endian machine

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-30
+ * @version: 2024-10-04
  *
  * General Notes:
  *
@@ -452,16 +452,16 @@ int main(int argc, char* argv[]) {
         printf("Example for train: main train data/labels data/images 0.1 true 3 786 100 10 1000 3 model.model\n\n");
         printf("This example has a learning rate of 0.1, uses biases, has 3 layers, and uses 1000 images to train on, over 3 epochs\n");
 
-        printf("Expected usage: main batch-train labels_path images_path learning_rate include_biases num_layers [layer_info] num_training_images batch_size epochs model_name\n");
+        printf("\n\nExpected usage: main batch-train labels_path images_path learning_rate include_biases num_layers [layer_info] num_training_images batch_size epochs model_name\n");
         printf("Example for train: main train data/labels data/images 0.1 true 3 786 100 10 1000 10 10 model.model\n\n");
         printf("This example has a learning rate of 0.1, uses biases, has 3 layers,uses 1000 images to train on, with a batch size of 10, and 10 epochs\n");
 
-        printf("Expected usage: main predict labels_path images_path num_predict model_path\n");
-        printf("Example for predict: main predict data/labels data/images 100 model.model\n");
+        printf("\n\nExpected usage: main predict labels_path images_path num_predict model_path\n");
+        printf("Example for predict: main predict data/labels data/images 100 model.model\n\n");
         printf("This example predicts 100 images");
 
-        printf("Expected usage: main threaded-predict labels_path images_path num_predict model_path\n");
-        printf("Example for predict: main threaded-predict data/labels data/images 100 model.model\n");
+        printf("\n\nExpected usage: main threaded-predict labels_path images_path num_predict model_path\n");
+        printf("Example for predict: main threaded-predict data/labels data/images 100 model.model\n\n");
         printf("This example predicts 100 images");
 
         return 0;

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,7 +8,7 @@
  *                                                                                                               
  * Project: Basic Neural Network in C
  * @author : Samuel Andersen
- * @version: 2024-09-30
+ * @version: 2024-10-04
  *
  * General Notes:
  *
@@ -16,11 +16,6 @@
  */
 
 #include "include/utils.h"
-
-float sigmoid(float z) {
-
-    return 1.0f / (1 + exp(-1 * z));
-}
 
 uint32_t map_uint32(uint32_t in) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__


### PR DESCRIPTION
Move `sigmoid` from `util.c` --> `Neural_Network.c`. Also use a generic function placeholder for activation, derivative, and delta. Allows for faster changes to ReLU, etc.

Store `z` as the pre-sigmoid activation vector.